### PR TITLE
Retry functionality in WorkerCommand

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,13 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
+
+env:
+  matrix:
+    - DEPENDENCIES="dev"
+    - DEPENDENCIES="high"
+    - DEPENDENCIES="low"
 
 cache:
   directories:
@@ -17,17 +23,18 @@ cache:
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm
     - php: 7.0
+    - php: 7.1
 
 before_install:
-  - composer selfupdate
+  - composer self-update
+  - composer clear-cache
   
 install:
   - export COMPOSER_ROOT_VERSION=dev-master
-  - if [ "$DEPENDENCIES" == "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-  - if [ "$DEPENDENCIES" != "low" ]; then composer update; fi;
-  - if [ "$DEPENDENCIES" == "low" ]; then composer update --prefer-lowest; fi;
+  - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+  - if [ "$DEPENDENCIES" = 'high' ]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable; fi
+  - if [ "$DEPENDENCIES" = 'low' ]; then travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable --prefer-lowest; fi
 
 before_script:
   - echo "<?php if (PHP_VERSION_ID >= 50400) echo ',@php5.4';" > php_version_tags.php

--- a/Tests/Vivait/DelayedEventBundle/ConfigurationTest.php
+++ b/Tests/Vivait/DelayedEventBundle/ConfigurationTest.php
@@ -3,9 +3,7 @@
 namespace Tests\Vivait\DelayedEventBundle;
 
 use Matthias\SymfonyConfigTest\PhpUnit\AbstractConfigurationTestCase;
-use Symfony\Component\Config\Definition\Processor;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\Yaml\Yaml;
 use Vivait\DelayedEventBundle\DependencyInjection\Configuration;
 
 class ConfigurationTest extends AbstractConfigurationTestCase

--- a/Tests/Vivait/DelayedEventBundle/EndToEndTest.php
+++ b/Tests/Vivait/DelayedEventBundle/EndToEndTest.php
@@ -3,26 +3,30 @@
 namespace Tests\Vivait\DelayedEventBundle;
 
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use Symfony\Component\Console\Output\NullOutput;
-use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Tests\Vivait\DelayedEventBundle\app\AppKernel;
+use Tests\Vivait\DelayedEventBundle\Mocks\TestExceptionListener;
 use Tests\Vivait\DelayedEventBundle\Mocks\TestListener;
 use Vivait\DelayedEventBundle\EventDispatcher\DelayedEventDispatcher;
-use Vivait\DelayedEventBundle\Queue\QueueInterface;
 
 /**
  * Checks that an end-to-end delayed event works
  */
 class EndToEndTest extends \PHPUnit_Framework_TestCase
 {
+    
     /**
      * @var ContainerBuilder
      */
     private $container;
+
+    /**
+     * @var string
+     */
     private $consolePath;
 
     /**
@@ -30,7 +34,10 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
      */
     private $application;
 
-    function __construct($consolePath = null)
+    /**
+     * @param null|string $consolePath
+     */
+    public function __construct($consolePath = null)
     {
         parent::__construct();
 
@@ -45,8 +52,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
         return $this->container->get('event_dispatcher');
     }
 
-
-    function setUp() {
+    public function setUp() {
         $kernel = new AppKernel('test', true);
         $kernel->boot();
 
@@ -56,6 +62,7 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
         $this->container = $kernel->getContainer();
 
         TestListener::reset();
+        TestExceptionListener::reset();
     }
 
     public function testListener()
@@ -67,9 +74,93 @@ class EndToEndTest extends \PHPUnit_Framework_TestCase
         $bufferedOutput = new BufferedOutput();
 
         $options = array('command' => 'vivait:delayed_event:worker', '-t' => 2, '--run-once' => true, '-v' => true);
-        $this->application->run(new \Symfony\Component\Console\Input\ArrayInput($options), $bufferedOutput);
+        $this->application->run(new ArrayInput($options), $bufferedOutput);
 
         \PHPUnit_Framework_Assert::assertContains('Performing job', $bufferedOutput->fetch());
         \PHPUnit_Framework_Assert::assertTrue(TestListener::$hasRan);
+    }
+
+    public function testThatAJobWillBeBuriedIfItDoesNotSucceedAfterAllRetriesAreUsed()
+    {
+        $this->getDispatcher()->dispatch('test.event.exception', new Event());
+
+        \PHPUnit_Framework_Assert::assertEquals(0, TestExceptionListener::$attempt);
+
+        $bufferedOutput = new BufferedOutput();
+
+        $options = [
+            'command' => 'vivait:delayed_event:worker',
+            '-t' => 2,
+            '--run-once' => true,
+            '-v' => true,
+            '-r' => 2 // Retry 2 times after the first failure (so it will have 3 attempts total)
+        ];
+
+        $this->application->run(new ArrayInput($options), $bufferedOutput);
+        
+        $output = $bufferedOutput->fetch();
+        
+        \PHPUnit_Framework_Assert::assertContains(
+            'Failed to perform event, attempt number 0 with exception: ',
+            $output
+        );
+        \PHPUnit_Framework_Assert::assertContains(
+            'Failed to perform event, attempt number 1 with exception: ',
+            $output
+        );
+        \PHPUnit_Framework_Assert::assertContains(
+            'Failed to perform event, attempt number 2 with exception: ',
+            $output
+        );
+        \PHPUnit_Framework_Assert::assertContains('Burying job', $output);
+    }
+
+    public function testThatAJobWillSucceedCorrectlyDuringRetries()
+    {
+        $this->getDispatcher()->dispatch('test.event.exception', new Event());
+
+        \PHPUnit_Framework_Assert::assertEquals(0, TestExceptionListener::$attempt);
+
+        $bufferedOutput = new BufferedOutput();
+
+        $options = [
+            'command' => 'vivait:delayed_event:worker',
+            '-t' => 2,
+            '--run-once' => true,
+            '-vvv' => true, // Very verbose mode to include `info` logs
+            '-r' => 3
+        ];
+
+        $this->application->run(new ArrayInput($options), $bufferedOutput);
+
+        $output = $bufferedOutput->fetch();
+        \PHPUnit_Framework_Assert::assertContains('Job finished successfully and removed', $output);
+        \PHPUnit_Framework_Assert::assertTrue(TestExceptionListener::$succeeded);
+    }
+
+    public function testThatNoRetriesWillOccurIfTheRetryOptionWasNotSet()
+    {
+        $this->getDispatcher()->dispatch('test.event.exception', new Event());
+
+        \PHPUnit_Framework_Assert::assertEquals(0, TestExceptionListener::$attempt);
+
+        $bufferedOutput = new BufferedOutput();
+
+        $options = [
+            'command' => 'vivait:delayed_event:worker',
+            '-t' => 2,
+            '--run-once' => true,
+            '-v' => true
+        ];
+
+        $this->application->run(new ArrayInput($options), $bufferedOutput);
+
+        $output = $bufferedOutput->fetch();
+
+        \PHPUnit_Framework_Assert::assertContains(
+            'Failed to perform event, attempt number 0 with exception: ',
+            $output
+        );
+        \PHPUnit_Framework_Assert::assertContains('Burying job', $output);
     }
 }

--- a/Tests/Vivait/DelayedEventBundle/Mocks/TestExceptionListener.php
+++ b/Tests/Vivait/DelayedEventBundle/Mocks/TestExceptionListener.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Vivait\DelayedEventBundle\Mocks;
+
+class TestExceptionListener
+{
+    /**
+     * @var int
+     */
+    public static $attempt = 0;
+
+    /**
+     * @var bool
+     */
+    public static $succeeded = false;
+
+    /**
+     * @param mixed $args
+     * 
+     * @throws \Exception
+     */
+    public function onListenEvent($args)
+    {
+        $throw = false;
+        
+        if (self::$attempt < 3) {
+            $throw = true;
+        }
+        
+        self::$attempt++;
+        
+        if ($throw) {
+            throw new \Exception();
+        }
+        
+        self::$succeeded = true;
+    }
+
+    /**
+     * Reset
+     */
+    public static function reset() {
+        self::$attempt = 0;
+        self::$succeeded = false;
+    }
+}

--- a/Tests/Vivait/DelayedEventBundle/app/config.yml
+++ b/Tests/Vivait/DelayedEventBundle/app/config.yml
@@ -27,3 +27,8 @@ services:
     class: Tests\Vivait\DelayedEventBundle\Mocks\TestListener
     tags:
       - { name: delayed_event.event_listener, delay: 0, event: test.event, method: onListenEvent }
+
+  test_vivait_delayed_event.listener.exception:
+    class: Tests\Vivait\DelayedEventBundle\Mocks\TestExceptionListener
+    tags:
+      - { name: delayed_event.event_listener, delay: 0, event: test.event.exception, method: onListenEvent }


### PR DESCRIPTION
Added the ability to 'retry' jobs by just dispatching the same event again.

The `-r` option in command specifies how many retries to do, defaulting at 0 to keep existing stuff working the same